### PR TITLE
Add FTPS support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ CHANGES
 - Interactive mode
 - Renamed _pyftpsync-meta.json to .pyftpsync-meta.json
 - MSI installer for MS Windows
+- FTPS (TLS) support on Python 2.7/3.2+
 
 0.2.1 (2013-05-07)
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,7 @@ Features
   * This is a command line tool...
   * ... and a library for use in your Python projects.
   * Upload, download, and bi-directional synch mode.
+  * FTPS (TLS) support on Python 2.7/3.2+.
   * Allows FTP-to-FTP and Filesystem-to-Filesystem synchronization as well.
   * Architecture is open to add other target types.
 
@@ -174,16 +175,18 @@ Example: Upload files
 Upload all new and modified files from user's temp folder to an FTP server. 
 No files are changed on the local directory::
 
-  $ pyftpsync upload ~/temp ftp://example.com/target/folder
+  $ pyftpsync upload ~/temp ftps://example.com/target/folder
 
 Add the ``--delete`` option to remove all files from the remote target that 
 don't exist locally::
 
-  $ pyftpsync upload ~/temp ftp://example.com/target/folder --delete
+  $ pyftpsync upload ~/temp ftps://example.com/target/folder --delete
 
 Add the ``-x`` option to switch from DRY-RUN mode to real execution::
 
-  $ pyftpsync upload ~/temp ftp://example.com/target/folder --delete -x
+  $ pyftpsync upload ~/temp ftps://example.com/target/folder --delete -x
+
+Replace ``ftps://`` with ``ftp://`` to disable TLS encryption.
 
 
 Synchronize files syntax
@@ -222,7 +225,7 @@ Example: Synchronize folders
 
 Two-way synchronization of a local folder with an FTP server::
 
-  $ pyftpsync sync --store-password --resolve=ask --execute ~/temp ftp://example.com/target/folder
+  $ pyftpsync sync --store-password --resolve=ask --execute ~/temp ftps://example.com/target/folder
 
 
 Script examples
@@ -236,7 +239,7 @@ Upload changes from local folder to FTP server::
   local = FsTarget("~/temp")
   user ="joe"
   passwd = "secret"
-  remote = FtpTarget("/temp", "example.com", user, passwd)
+  remote = FtpTarget("/temp", "example.com", user, passwd, tls=True)
   opts = {"force": False, "delete_unmatched": True, "verbose": 3, "dry_run" : False}
   s = UploadSynchronizer(local, remote, opts)
   s.run()
@@ -249,7 +252,7 @@ Synchronize local folder with FTP server::
   local = FsTarget("~/temp")
   user ="joe"
   passwd = "secret"
-  remote = FtpTarget("/temp", "example.com", user, passwd)
+  remote = FtpTarget("/temp", "example.com", user, passwd, tls=True)
   opts = {"resolve": "skip", "verbose": 1, "dry_run" : False}
   s = BiDirSynchronizer(local, remote, opts)
   s.run()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -233,8 +233,9 @@ Script examples
 
 Upload changes from local folder to FTP server::
 
-  from ftpsync.targets import FsTarget, UploadSynchronizer
+  from ftpsync.targets import FsTarget
   from ftpsync.ftp_target import FtpTarget
+  from ftpsync.synchronizers import UploadSynchronizer
 
   local = FsTarget("~/temp")
   user ="joe"
@@ -246,8 +247,9 @@ Upload changes from local folder to FTP server::
 
 Synchronize local folder with FTP server::
 
-  from ftpsync.targets import FsTarget, BiDirSynchronizer
+  from ftpsync.targets import FsTarget
   from ftpsync.ftp_target import FtpTarget
+  from ftpsync.synchronizers import BiDirSynchronizer
 
   local = FsTarget("~/temp")
   user ="joe"

--- a/ftpsync/pyftpsync.py
+++ b/ftpsync/pyftpsync.py
@@ -7,7 +7,7 @@ Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.p
 
 Usage examples:
   > pyftpsync.py --help
-  > pyftpsync.py upload . ftp://example.com/myfolder
+  > pyftpsync.py upload . ftps://example.com/myfolder
 """
 from __future__ import print_function
 

--- a/ftpsync/targets.py
+++ b/ftpsync/targets.py
@@ -52,11 +52,11 @@ def prompt_for_password(url, user=None):
     if user is None:
         default_user = getpass.getuser()
         while user is None:
-            user = console_input("Enter username for ftp://%s [%s]: " % (url, default_user))
+            user = console_input("Enter username for %s [%s]: " % (url, default_user))
             if user.strip() == "" and default_user:
                 user = default_user
     if user:
-        pw = getpass.getpass("Enter password for ftp://%s@%s: " % (user, url))
+        pw = getpass.getpass("Enter password for %s@%s: " % (user, url))
         if pw:
             return (user, pw)
     return None
@@ -145,15 +145,21 @@ def ansi_code(name):
 # make_target
 #===============================================================================
 def make_target(url, extra_opts=None):
-    """Factory that creates _Target objects from URLs."""
+    """Factory that creates _Target objects from URLs.
+
+    FTP targets must begin with the scheme ftp:// or ftps:// for TLS.
+    TLS is only supported on Python 2.7/3.2+.
+    """
 #    debug = extra_opts.get("debug", 1)
     parts = urlparse(url, allow_fragments=False)
     # scheme is case-insensitive according to http://tools.ietf.org/html/rfc3986
-    if parts.scheme.lower() == "ftp":
+    scheme = parts.scheme.lower()
+    if scheme in ["ftp", "ftps"]:
         creds = parts.username, parts.password
+        tls = scheme == "ftps"
         from ftpsync import ftp_target
         target = ftp_target.FtpTarget(parts.path, parts.hostname, parts.port,
-                                      creds[0], creds[1], extra_opts)
+                                      creds[0], creds[1], tls, extra_opts)
     else:
         target = FsTarget(url, extra_opts)
 

--- a/test/test_ftp.py
+++ b/test/test_ftp.py
@@ -403,14 +403,16 @@ class PlainTest(unittest.TestCase):
 
         t = make_target("ftps://user@example.com:secret@ftp.example.com/target/folder")
         self.assertTrue(isinstance(t, FtpTarget))
-        self.assertEqual(t.username, "www.user.com")
+        self.assertEqual(t.host, "ftp.example.com")
+        self.assertEqual(t.username, "user@example.com")
         self.assertEqual(t.password, "secret")
         self.assertEqual(t.root_dir, "/target/folder")
         self.assertEqual(t.tls, True)
 
         t = make_target("ftp://user@example.com:secret@ftp.example.com/target/folder")
         self.assertTrue(isinstance(t, FtpTarget))
-        self.assertEqual(t.username, "www.user.com")
+        self.assertEqual(t.host, "ftp.example.com")
+        self.assertEqual(t.username, "user@example.com")
         self.assertEqual(t.password, "secret")
         self.assertEqual(t.root_dir, "/target/folder")
         self.assertEqual(t.tls, False)

--- a/test/test_ftp.py
+++ b/test/test_ftp.py
@@ -17,6 +17,15 @@ else:
     import unittest
     from unittest.case import SkipTest
 
+# Python 2.7/3.2+ supports ftps://.
+if (sys.version_info.major == 2 and sys.version_info >= (2, 7)) or \
+        (sys.version_info.major == 3 and sys.version_info >= (3, 2)):
+    tls = True
+    scheme = 'ftps'
+else:
+    tls = False
+    scheme = 'ftp'
+
 from ftpsync.ftp_target import *  # @UnusedWildImport
 from ftpsync.targets import *  # @UnusedWildImport
 
@@ -377,37 +386,39 @@ class PlainTest(unittest.TestCase):
         pass
 
     def test_make_target(self):
-        t = make_target("ftps://ftp.example.com/target/folder")
+        t = make_target(scheme + "://ftp.example.com/target/folder")
         self.assertTrue(isinstance(t, FtpTarget))
         self.assertEqual(t.host, "ftp.example.com")
         self.assertEqual(t.root_dir, "/target/folder")
         self.assertEqual(t.username, None)
-        self.assertEqual(t.tls, True)
+        self.assertEqual(t.tls, tls)
 
         # scheme is case-insensitive
-        t = make_target("FTPS://ftp.example.com/target/folder")
+        t = make_target(scheme.upper() + "://ftp.example.com/target/folder")
         self.assertTrue(isinstance(t, FtpTarget))
         self.assertEqual(t.host, "ftp.example.com")
         self.assertEqual(t.root_dir, "/target/folder")
         self.assertEqual(t.username, None)
-        self.assertEqual(t.tls, True)
+        self.assertEqual(t.tls, tls)
 
         # pass credentials wit URL
-        t = make_target("ftps://user:secret@ftp.example.com/target/folder")
+        t = make_target(scheme +
+                        "://user:secret@ftp.example.com/target/folder")
         self.assertTrue(isinstance(t, FtpTarget))
         self.assertEqual(t.host, "ftp.example.com")
         self.assertEqual(t.username, "user")
         self.assertEqual(t.password, "secret")
         self.assertEqual(t.root_dir, "/target/folder")
-        self.assertEqual(t.tls, True)
+        self.assertEqual(t.tls, tls)
 
-        t = make_target("ftps://user@example.com:secret@ftp.example.com/target/folder")
+        t = make_target(scheme +
+                        "://user@example.com:secret@ftp.example.com/target/folder")
         self.assertTrue(isinstance(t, FtpTarget))
         self.assertEqual(t.host, "ftp.example.com")
         self.assertEqual(t.username, "user@example.com")
         self.assertEqual(t.password, "secret")
         self.assertEqual(t.root_dir, "/target/folder")
-        self.assertEqual(t.tls, True)
+        self.assertEqual(t.tls, tls)
 
         t = make_target("ftp://user@example.com:secret@ftp.example.com/target/folder")
         self.assertTrue(isinstance(t, FtpTarget))

--- a/test/test_ftp.py
+++ b/test/test_ftp.py
@@ -17,15 +17,6 @@ else:
     import unittest
     from unittest.case import SkipTest
 
-# Python 2.7/3.2+ supports ftps://.
-if (sys.version_info.major == 2 and sys.version_info >= (2, 7)) or \
-        (sys.version_info.major == 3 and sys.version_info >= (3, 2)):
-    tls = True
-    scheme = 'ftps'
-else:
-    tls = False
-    scheme = 'ftp'
-
 from ftpsync.ftp_target import *  # @UnusedWildImport
 from ftpsync.targets import *  # @UnusedWildImport
 
@@ -386,47 +377,42 @@ class PlainTest(unittest.TestCase):
         pass
 
     def test_make_target(self):
-        t = make_target(scheme + "://ftp.example.com/target/folder")
-        self.assertTrue(isinstance(t, FtpTarget))
-        self.assertEqual(t.host, "ftp.example.com")
-        self.assertEqual(t.root_dir, "/target/folder")
-        self.assertEqual(t.username, None)
-        self.assertEqual(t.tls, tls)
+        for scheme in ['ftp', 'ftps']:
+            tls = True if scheme == 'ftps' else False
 
-        # scheme is case-insensitive
-        t = make_target(scheme.upper() + "://ftp.example.com/target/folder")
-        self.assertTrue(isinstance(t, FtpTarget))
-        self.assertEqual(t.host, "ftp.example.com")
-        self.assertEqual(t.root_dir, "/target/folder")
-        self.assertEqual(t.username, None)
-        self.assertEqual(t.tls, tls)
+            t = make_target(scheme + "://ftp.example.com/target/folder")
+            self.assertTrue(isinstance(t, FtpTarget))
+            self.assertEqual(t.host, "ftp.example.com")
+            self.assertEqual(t.root_dir, "/target/folder")
+            self.assertEqual(t.username, None)
+            self.assertEqual(t.tls, tls)
 
-        # pass credentials wit URL
-        t = make_target(scheme +
-                        "://user:secret@ftp.example.com/target/folder")
-        self.assertTrue(isinstance(t, FtpTarget))
-        self.assertEqual(t.host, "ftp.example.com")
-        self.assertEqual(t.username, "user")
-        self.assertEqual(t.password, "secret")
-        self.assertEqual(t.root_dir, "/target/folder")
-        self.assertEqual(t.tls, tls)
+            # scheme is case-insensitive
+            t = make_target(scheme.upper() + "://ftp.example.com/target/folder")
+            self.assertTrue(isinstance(t, FtpTarget))
+            self.assertEqual(t.host, "ftp.example.com")
+            self.assertEqual(t.root_dir, "/target/folder")
+            self.assertEqual(t.username, None)
+            self.assertEqual(t.tls, tls)
 
-        t = make_target(scheme +
-                        "://user@example.com:secret@ftp.example.com/target/folder")
-        self.assertTrue(isinstance(t, FtpTarget))
-        self.assertEqual(t.host, "ftp.example.com")
-        self.assertEqual(t.username, "user@example.com")
-        self.assertEqual(t.password, "secret")
-        self.assertEqual(t.root_dir, "/target/folder")
-        self.assertEqual(t.tls, tls)
+            # pass credentials with URL
+            url = 'user:secret@ftp.example.com/target/folder'
+            t = make_target(scheme + "://" + url)
+            self.assertTrue(isinstance(t, FtpTarget))
+            self.assertEqual(t.host, "ftp.example.com")
+            self.assertEqual(t.username, "user")
+            self.assertEqual(t.password, "secret")
+            self.assertEqual(t.root_dir, "/target/folder")
+            self.assertEqual(t.tls, tls)
 
-        t = make_target("ftp://user@example.com:secret@ftp.example.com/target/folder")
-        self.assertTrue(isinstance(t, FtpTarget))
-        self.assertEqual(t.host, "ftp.example.com")
-        self.assertEqual(t.username, "user@example.com")
-        self.assertEqual(t.password, "secret")
-        self.assertEqual(t.root_dir, "/target/folder")
-        self.assertEqual(t.tls, False)
+            url = 'user@example.com:secret@ftp.example.com/target/folder'
+            t = make_target(scheme + "://" + url)
+            self.assertTrue(isinstance(t, FtpTarget))
+            self.assertEqual(t.host, "ftp.example.com")
+            self.assertEqual(t.username, "user@example.com")
+            self.assertEqual(t.password, "secret")
+            self.assertEqual(t.root_dir, "/target/folder")
+            self.assertEqual(t.tls, tls)
 
         # unsupported schemes
         self.assertRaises(ValueError, make_target, "ftpa://ftp.example.com/test")

--- a/test/test_regressions.py
+++ b/test/test_regressions.py
@@ -48,13 +48,13 @@ def tearDownModule():
 class RegressionTest(unittest.TestCase):
     """Test basic ftplib.FTP functionality."""
     def setUp(self):
-        # Remote URL, e.g. "ftp://user:password@example.com/my/test/folder"
+        # Remote URL, e.g. "ftps://user:password@example.com/my/test/folder"
         ftp_url = PYFTPSYNC_TEST_FTP_URL
         if not ftp_url:
             self.skipTest("Must configure a FTP target (environment variable PYFTPSYNC_TEST_FTP_URL)")
 
         parts = urlparse(ftp_url, allow_fragments=False)
-        # self.assertEqual(parts.scheme.lower(), "ftp")
+        # self.assertIn(parts.scheme.lower(), ["ftp", "ftps"])
         self.host = parts.netloc.split("@", 1)[1]
         self.path = parts.path
         self.username = parts.username


### PR DESCRIPTION
Support FTPS (TLS) on Python 2.7/3.2+ where ftplib.FTP_TLS exists.
Also change examples to show ftps:// but retain non-TLS default
for backwards-compatibility.

Would like to use pyftpsync with [Lektor](https://github.com/lektor/lektor).