### PR TITLE
FTP socket connection not closed after calling close() method.

### DIFF
--- a/ftpsync/ftp_target.py
+++ b/ftpsync/ftp_target.py
@@ -72,6 +72,8 @@ class FtpTarget(_Target):
         self.is_unix = None
         self.time_zone_ofs = None
         self.clock_ofs = None
+        self.ftp_socket_connected = False
+        self.connected = False
 #        if connect:
 #            self.open()
 
@@ -89,6 +91,8 @@ class FtpTarget(_Target):
         store_password = self.get_option("store_password", False)
 
         self.ftp.connect(self.host, self.port, self.timeout)
+
+        self.ftp_socket_connected = True
 
         if self.username is None or self.password is None:
             creds = get_credentials_for_url(self.host, allow_prompt=not no_prompt)
@@ -142,7 +146,10 @@ class FtpTarget(_Target):
     def close(self):
         if self.connected:
             self._unlock(closing=True)
+
+        if self.ftp_socket_connected:
             self.ftp.quit()
+
         self.connected = False
 
     def _lock(self, break_existing=False):


### PR DESCRIPTION
Running a script like that socket connection remains opened after calling close() method:

```
try:
     path = '/invalid/path'
     remote = FtpTarget(path, host, port, username, password, tls, timeout)
     remote.open()
except RuntimeError as e:
     remote.close()  
```

Connected flag is set after change directory is done so if anything goes wrong between connecting to the ftp server and changing directory to root_dir, ftp socket remains opened even when calling close() method.